### PR TITLE
Jessie's repos have moved to debian's archive

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,8 @@ FROM ${IMAGE}
 ARG GO_TAGS
 ENV GO_TAGS=${GO_TAGS}
 
+RUN printf "deb http://archive.debian.org/debian/ jessie main\ndeb-src http://archive.debian.org/debian/ jessie main\ndeb http://security.debian.org jessie/updates main\ndeb-src http://security.debian.org jessie/updates main" > /etc/apt/sources.list
+
 RUN apt-get update && apt-get install -y --no-install-recommends \
   git build-essential \
   debhelper devscripts fakeroot git-buildpackage dh-make dh-systemd dh-golang \


### PR DESCRIPTION
I got an error while trying to build OctoPrint-TFT

```
pi@octopi:~/OctoPrint-TFT $ make build
mkdir -p /home/pi/OctoPrint-TFT/build
docker build \
        --build-arg IMAGE=golang:1.8-jessie \
        --build-arg GO_TAGS=gtk_3_14 \
        -t mcuadros/octoprint-tft-build:jessie . \
        && \
docker run -it --rm \
        -v /home/pi/OctoPrint-TFT/build/jessie:/build \
        mcuadros/octoprint-tft-build:jessie \
        make build-internal
Sending build context to Docker daemon  15.14MB
Step 1/7 : ARG IMAGE
Step 2/7 : FROM ${IMAGE}
 ---> 041a47a0d713
Step 3/7 : ARG GO_TAGS
 ---> Using cache
 ---> fd6529d2fbd1
Step 4/7 : ENV GO_TAGS=${GO_TAGS}
 ---> Using cache
 ---> ad7003987688
Step 5/7 : RUN apt-get update && apt-get install -y --no-install-recommends   git build-essential   debhelper devscripts fakeroot git-buildpackage dh-make dh-systemd dh-golang   libcairo2-dev   libgtk-3-dev
 ---> Running in 22542349d0a3
Get:1 http://security.debian.org jessie/updates InRelease [44.9 kB]
Ign http://deb.debian.org jessie InRelease
Get:2 http://deb.debian.org jessie-updates InRelease [7340 B]
Get:3 http://deb.debian.org jessie Release.gpg [2420 B]
Get:4 http://deb.debian.org jessie Release [148 kB]
Get:5 http://security.debian.org jessie/updates/main armhf Packages [816 kB]
Get:6 http://deb.debian.org jessie/main armhf Packages [8898 kB]
Fetched 9917 kB in 1min 13s (135 kB/s)
W: Failed to fetch http://deb.debian.org/debian/dists/jessie-updates/InRelease  Unable to find expected entry 'main/binary-armhf/Packages' in Release file (Wrong sources.list entry or malformed file)

E: Some index files failed to download. They have been ignored, or old ones used instead.
The command '/bin/sh -c apt-get update && apt-get install -y --no-install-recommends   git build-essential   debhelper devscripts fakeroot git-buildpackage dh-make dh-systemd dh-golang   libcairo2-dev   libgtk-3-dev' returned a non-zero code: 100
Makefile:52: recipe for target 'JESSIE' failed
make: *** [JESSIE] Error 100
```

A little digging and I found out that [Wheezy and Jessie were recently removed from the mirror network](https://lists.debian.org/debian-devel-announce/2019/03/msg00006.html) thanks to [this post](A little digging and I found out that [Wheezy and Jessie were recently removed from the mirror network](https://lists.debian.org/debian-devel-announce/2019/03/msg00006.html).

I modified Dockerfile accordingly.
